### PR TITLE
Change: Add US English lang

### DIFF
--- a/src/lang/english_US.toml
+++ b/src/lang/english_US.toml
@@ -1,0 +1,1010 @@
+[GLOBAL_PRAGMA]
+grflangid = 0x02
+plural = 0
+
+[STR_GRF_DESCRIPTION]
+base = "License: {SILVER}GPL v2{}{BLACK}"
+
+# parameters (action 14 etc)
+[STR_PARAM_ADD_RAILTYPES]
+base = "Iron Horse extra rail types"
+# substrings of the grf name _could_ be used here
+ibex = "Iron Ibex extra rail types"
+moose = "Iron Moose extra rail types"
+
+[STR_PARAM_ADD_RAILTYPES_DESC]
+base = "Iron Horse includes trains that require extra rail types, for example metro and narrow gauge.  These types can also be provided by alternative rail type grfs.  If alternative rail type grfs are used, the Iron Horse rail types can be turned off with this parameter setting."
+# substrings of the grf name _could_ be used here
+ibex = "Iron Ibex includes trains that require extra rail types, for example metro and narrow gauge.  These types can also be provided by alternative rail type grfs.  If alternative rail type grfs are used, the Iron Ibex rail types can be turned off with this parameter setting."
+moose = "Iron Moose includes trains that require extra rail types, for example metro and narrow gauge.  These types can also be provided by alternative rail type grfs.  If alternative rail type grfs are used, the Iron Moose rail types can be turned off with this parameter setting."
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY]
+base = "Train capacity"
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY_DESC]
+base = "Adjust vehicle capacity for alternative gameplay styles.{}{}Nanoscopic: {GOLD}77% reduction{BLACK}{}Puny: {GOLD}33% reduction{BLACK}{}Marvellous: {GOLD}default{BLACK}{}Excessive: {GOLD}33% increase{BLACK}{}Outrageous: {GOLD}77% increase{BLACK}"
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY_OPTION_0]
+base = "Nanoscopic"
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY_OPTION_1]
+base = "Puny"
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY_OPTION_2]
+base = "Marvellous (default)"
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY_OPTION_3]
+base = "Excessive"
+
+[STR_PARAM_ADJUST_VEHICLE_CAPACITY_OPTION_4]
+base = "Outrageous"
+
+[STR_PARAM_SIMPLIFIED_GAMEPLAY]
+base = "Simplified gameplay"
+
+[STR_PARAM_SIMPLIFIED_GAMEPLAY_DESC]
+base = "Play with a simplified set of trains. There will be fewer types of engines and rail cars available.  Eye-candy trains like snowplows, driving cab cars and very slow locomotives will not be available."
+
+[STR_PARAM_WAGONS_ONLY_MODE]
+base = "Rail cars only mode"
+
+[STR_PARAM_WAGONS_ONLY_MODE_DESC]
+base = "Play with only rail cars. All engines, snowplows etc will be hidden.{}{}Can also be used with 'Simplified gameplay' to reduce the range of rail cars if desired.{}{}Note that this option only makes sense if at least one other grf with engines is used in the game.{}{}Rail cars will not appear in the game if there are no engines matching their rail type."
+
+[STR_PARAM_WAGON_COLOUR_RANDOMISATION]
+base = "Rail car color fading"
+
+[STR_PARAM_WAGON_COLOUR_RANDOMISATION_STRATEGY_DESC]
+base = "Faded freight rail car colors add variety to trains (random chance each rail car is faded)."
+
+[STR_ERROR_INFLATION_INCOMPATIBLE]
+base = "Iron Horse is not compatible with OpenTTD Inflation. Please turn Inflation off in OpenTTD settings."
+# substrings of the grf name _could_ be used here
+ibex = "Iron Ibex is not compatible with OpenTTD Inflation. Please turn Inflation off in OpenTTD settings."
+moose = "Iron Moose is not compatible with OpenTTD Inflation. Please turn Inflation off in OpenTTD settings."
+
+[STR_ERROR_TERMITE_DEPRECATED]
+base = "Iron Horse now includes the rail types from Termite. Please remove Termite from the NewGRF list and try a new game. Thanks."
+# substrings of the grf name _could_ be used here
+ibex = "Iron Ibex includes the rail types from Termite. Please remove Termite from the NewGRF list and try a new game. Thanks."
+moose = "Iron Moose includes the rail types from Termite. Please remove Termite from the NewGRF list and try a new game. Thanks."
+
+# default colours - reuses the constants for the company colour names, so 'COLOUR_' is repeated again in the trailing part of some string names
+[STR_COLOUR_NAME_COLOUR_DARK_BLUE]
+base = "Dark Blue"
+
+[STR_COLOUR_NAME_COLOUR_PALE_GREEN]
+base = "Pale Green"
+
+[STR_COLOUR_NAME_COLOUR_PINK]
+base = "Pink"
+
+[STR_COLOUR_NAME_COLOUR_YELLOW]
+base = "Yellow"
+
+[STR_COLOUR_NAME_COLOUR_RED]
+base = "Red"
+
+[STR_COLOUR_NAME_COLOUR_LIGHT_BLUE]
+base = "Light Blue"
+
+[STR_COLOUR_NAME_COLOUR_GREEN]
+base = "Green"
+
+[STR_COLOUR_NAME_COLOUR_DARK_GREEN]
+base = "Dark Green"
+
+[STR_COLOUR_NAME_COLOUR_BLUE]
+base = "Blue"
+
+[STR_COLOUR_NAME_COLOUR_CREAM]
+base = "Cream"
+
+[STR_COLOUR_NAME_COLOUR_MAUVE]
+base = "Mauve"
+
+[STR_COLOUR_NAME_COLOUR_PURPLE]
+base = "Purple"
+
+[STR_COLOUR_NAME_COLOUR_ORANGE]
+base = "Orange"
+
+[STR_COLOUR_NAME_COLOUR_BROWN]
+base = "Brown"
+
+[STR_COLOUR_NAME_COLOUR_GREY]
+base = "Grey"
+
+[STR_COLOUR_NAME_COLOUR_WHITE]
+base = "White"
+
+# custom colours - avoid metaphor/narrative names for the colours, they confuse people, stick to actual real colours
+[STR_COLOUR_NAME_CUSTOM_BAUXITE]
+base = "Brown"
+
+[STR_COLOUR_NAME_CUSTOM_DARK_GREY]
+base = "Grey"
+
+[STR_COLOUR_NAME_CUSTOM_GREMLIN_GREEN]
+base = "Green"
+
+[STR_COLOUR_NAME_CUSTOM_NIGHTSHADE]
+base = "Black"
+
+[STR_COLOUR_NAME_CUSTOM_OCHRE]
+base = "Ochre"
+
+[STR_COLOUR_NAME_CUSTOM_OIL_BLACK]
+base = "Oil Black"
+
+[STR_COLOUR_NAME_CUSTOM_PEWTER]
+base = "Pewter"
+
+[STR_COLOUR_NAME_CUSTOM_RUBY]
+base = "Dark Red"
+
+[STR_COLOUR_NAME_CUSTOM_SILVER]
+base = "Silver"
+
+[STR_COLOUR_NAME_CUSTOM_STRAW]
+base = "Straw"
+
+[STR_COLOUR_NAME_CUSTOM_SULPHUR]
+base = "Mustard"
+
+[STR_COLOUR_NAME_CUSTOM_TEAL]
+base = "Teal"
+
+[STR_COLOUR_NAME_CUSTOM_VIOLET]
+base = "Violet"
+
+# livery name suffixes - fancy names are better here, as there can be more than 2 colours, so the names give a flavour
+[STR_NAME_SUFFIX_LIVERY_MIX_1]
+base = "- {STRING}/{STRING}"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_2]
+base = "Variety"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_3]
+base = "Rust/Shale"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_4]
+base = "Seafoam/Amethyst"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_5]
+base = "Silver/Pewter"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_6]
+base = "Mustard/Ochre"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_7]
+base = "Ruby/Rust"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_8]
+base = "Obsidian/Nightshade"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_9]
+base = "Ochre/Straw"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_10]
+base = "Moss/Silver"
+
+[STR_NAME_SUFFIX_LIVERY_MIX_11]
+base = "Mustard/Straw"
+
+# keep these alphabetised, easier
+[STR_NAME_SUFFIX_BATTERY_HYBRID]
+base = "Battery Hybrid"
+
+[STR_NAME_SUFFIX_DIESEL]
+base = "Diesel"
+
+[STR_NAME_SUFFIX_ELECTRIC_AC]
+base = "AC Electric"
+
+[STR_NAME_SUFFIX_ELECTRIC_DC]
+base = "DC Electric"
+
+[STR_NAME_SUFFIX_ELECTRIC_AC_DC]
+base = "AC/DC Electric"
+
+[STR_NAME_SUFFIX_ELECTRODIESEL]
+base = "Electro-Diesel"
+
+[STR_NAME_SUFFIX_METRO]
+base = "Metro"
+
+[STR_NAME_SUFFIX_STEAM]
+base = "Steam"
+
+[STR_NAME_SUFFIX_TRAILER]
+base = "Trailer"
+
+# size suffixes
+[STR_NAME_SUFFIX_SMALL]
+base = "Small"
+
+[STR_NAME_SUFFIX_MEDIUM]
+base = "Medium"
+
+[STR_NAME_SUFFIX_LARGE]
+base = "Large"
+
+# special feature suffixes
+[STR_NAME_SUFFIX_TWIN]
+base = "Twin"
+
+[STR_NAME_SUFFIX_RANDOMISED_WAGON]
+base = " - Random"
+
+[STR_NAME_SUFFIX_MIXED_COLOURS]
+base = " - {RED}M{ORANGE}i{YELLOW}x{GREEN}e{BLUE}d {PURPLE}C{RED}o{ORANGE}l{YELLOW}o{GREEN}u{BLUE}r{PURPLE}s"
+
+# names for buyable variant groups
+[STR_WAGON_GROUP_ACID_TANK_CARS]
+base = "Acid Tank Cars"
+
+[STR_WAGON_GROUP_AGGREGATE_DUMP_CARS]
+base = "Aggregate Dump Cars"
+
+[STR_WAGON_GROUP_AGGREGATE_HOPPER_CARS]
+base = "Aggregate Hoppers"
+
+[STR_WAGON_GROUP_BOLSTER_CARS]
+base = "Bolster Cars"
+
+[STR_WAGON_GROUP_BOX_CARS]
+base = "Boxcars"
+
+[STR_WAGON_GROUP_BULKHEAD_FLAT_CARS]
+base = "Bulkhead Flatcars"
+
+[STR_WAGON_GROUP_CEMENT_SILO_CARS]
+base = "Cement Cars"
+
+[STR_WAGON_GROUP_COIL_BUGGY_CARS]
+base = "Coil Buggies"
+
+[STR_WAGON_GROUP_COIL_CARS]
+base = "Coil Cars"
+
+[STR_WAGON_GROUP_COVERED_HOPPER_CARS]
+base = "Covered Hoppers"
+
+[STR_WAGON_GROUP_DUMP_CARS]
+base = "Mineral Hoppers"
+
+[STR_WAGON_GROUP_EDIBLES_TANK_CARS]
+base = "Edibles Tank Cars"
+
+[STR_WAGON_GROUP_EXPRESS_CARS]
+base = "Express Boxcars"
+
+[STR_WAGON_GROUP_FARM_PRODUCT_CARS]
+base = "Farm Product Boxcars"
+
+[STR_WAGON_GROUP_FLAT_CARS]
+base = "Flatcars"
+
+[STR_WAGON_GROUP_HOPPER_CARS]
+base = "Hoppers"
+
+[STR_WAGON_GROUP_INGOT_CARS]
+base = "Ingot Cars"
+
+[STR_WAGON_GROUP_INTERMODAL_CARS]
+base = "Container Cars"
+
+[STR_WAGON_GROUP_LIVESTOCK_CARS]
+base = "Livestock Boxcars"
+
+[STR_WAGON_GROUP_LOG_CARS]
+# Timber Wagon was tried as name, but is confusing as it carries logs but NOT timber
+base = "Log Flatcar"
+
+[STR_WAGON_GROUP_MAIL_CARS]
+base = "Mail Cars"
+
+[STR_WAGON_GROUP_MGR_HOPPER_CARS]
+base = "MGR Hoppers"
+
+[STR_WAGON_GROUP_OPEN_CARS]
+base = "Open Cars"
+
+[STR_WAGON_GROUP_PASSENGER_CARS]
+base = "Passenger Cars"
+
+[STR_WAGON_GROUP_PLATE_CARS]
+base = "Plate Cars"
+
+[STR_WAGON_GROUP_PRESSURE_TANK_CARS]
+base = "Pressurised Tank Cars"
+
+[STR_WAGON_GROUP_PRODUCT_TANK_CARS]
+base = "Product Tank Cars"
+
+[STR_WAGON_GROUP_RANDOMISED_BOX_CARS]
+base = "Boxcars"
+
+[STR_WAGON_GROUP_RANDOMISED_BULK_CARS]
+base = "Bulk Cars"
+
+[STR_WAGON_GROUP_RANDOMISED_CHEMICALS_TANK_CARS]
+base = "Chemical Tank Cars"
+
+[STR_WAGON_GROUP_RANDOMISED_COVERED_HOPPER_CARS]
+base = "Covered Hoppers"
+
+[STR_WAGON_GROUP_RANDOMISED_DUMP_CARS]
+base = "Mineral Hoppers"
+
+[STR_WAGON_GROUP_RANDOMISED_FLAT_CARS]
+base = "Cargo Flatcars"
+
+[STR_WAGON_GROUP_RANDOMISED_HOPPER_CARS]
+base = "Hoppers"
+
+[STR_WAGON_GROUP_RANDOMISED_GENERIC_COIL_CARS]
+base = "Coil Cars"
+
+[STR_WAGON_GROUP_RANDOMISED_OPEN_CARS]
+base = "Open Cars"
+moose = "Gondolas"
+
+[STR_WAGON_GROUP_RANDOMISED_PIECE_GOODS_CARS]
+base = "Piece Goods Cars"
+
+[STR_WAGON_GROUP_REEFER_CARS]
+base = "Refrigerated Boxcars"
+
+[STR_WAGON_GROUP_RESTAURANT_CARS]
+base = "Restaurant Cars"
+
+[STR_WAGON_GROUP_ROCK_HOPPER_CARS]
+base = "Rock Hoppers"
+
+[STR_WAGON_GROUP_ROLLER_ROOF_HOPPER_CARS]
+base = "Roller Roof Hoppers"
+
+[STR_WAGON_GROUP_SILO_CARS]
+base = "Silo Cars"
+
+[STR_WAGON_GROUP_SKIP_CARS]
+base = "Skips"
+
+[STR_WAGON_GROUP_SLAG_LADLE_CARS]
+base = "Slag Ladle Cars"
+
+[STR_WAGON_GROUP_SLIDING_WALL_CARS]
+base = "Sliding Wall Boxcars"
+
+[STR_WAGON_GROUP_SUBURBAN_PASSENGER_CARS]
+base = "Suburban Cars"
+
+[STR_WAGON_GROUP_SWING_ROOF_HOPPER_CARS]
+base = "Swing Roof Hoppers"
+
+[STR_WAGON_GROUP_TANK_CARS]
+base = "Tank Cars"
+
+[STR_WAGON_GROUP_TARPAULIN_CARS]
+base = "Tarpaulin Cars"
+
+[STR_WAGON_GROUP_TORPEDO_CARS]
+base = "Torpedo Cars"
+
+[STR_WAGON_GROUP_VEHICLE_TRANSPORTER_CARS]
+base = "Autoracks"
+
+[STR_WAGON_GROUP_MORE]
+# special case
+base = "More..."
+
+# wagon class suffixes, as of Jan 2019 these are switched from en-us to en-gb; !! consider splitting strings per roster?? A US caboose is still a 'caboose' in en-gb, not a brake van
+[STR_NAME_SUFFIX_ACID_TANK_CAR]
+base = "Acid Tank Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_DUMP_CAR_TYPE_1]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_DUMP_CAR_TYPE_2]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_DUMP_CAR_TYPE_3]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_DUMP_CAR_TYPE_4]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_DUMP_CAR_TYPE_5]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_DUMP_CAR_TYPE_6]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_AGGREGATE_HOPPER_CAR_TYPE_1]
+base = "Aggregate Hopper"
+
+[STR_NAME_SUFFIX_AGGREGATE_HOPPER_CAR_TYPE_2]
+base = "Aggregate Hopper"
+
+[STR_NAME_SUFFIX_AGGREGATE_HOPPER_CAR_TYPE_3]
+base = "Aggregate Hopper"
+
+[STR_NAME_SUFFIX_ALIGNMENT_CAR]
+base = "Alignment Car"
+
+[STR_NAME_SUFFIX_AUTOMOBILE_CAR]
+base = "Autorack"
+
+[STR_NAME_SUFFIX_BOX_CAR]
+base = "Boxcar"
+
+[STR_NAME_SUFFIX_COIL_BUGGY_CAR]
+base = "Coil Buggies"
+
+[STR_NAME_SUFFIX_BOLSTER_CAR]
+base = "Bolster Car"
+
+[STR_NAME_SUFFIX_BULKHEAD_FLAT_CAR]
+base = "Bulkhead Flatcar"
+
+[STR_NAME_SUFFIX_CABOOSE_CAR]
+base = "Caboose"
+
+[STR_NAME_SUFFIX_CARBON_BLACK_HOPPER_CAR]
+base = "Carbon Black Hopper"
+
+[STR_NAME_SUFFIX_CEMENT_SILO_CAR]
+base = "Cement Car"
+
+[STR_NAME_SUFFIX_CEMENT_SILO_CAR_V_BARREL]
+base = "Cement Car"
+
+[STR_NAME_SUFFIX_CHEMICAL_COVERED_HOPPER_CAR]
+base = "Chemical Covered Hopper"
+
+[STR_NAME_SUFFIX_COIL_CAR_COVERED]
+base = "Covered Coil Carrier"
+
+[STR_NAME_SUFFIX_COIL_CAR_COVERED_ASYMMETRIC]
+base = "Covered Coil Carrier"
+
+[STR_NAME_SUFFIX_COIL_CAR_UNCOVERED]
+base = "Coil Carrier"
+
+[STR_NAME_SUFFIX_COVERED_HOPPER_CAR]
+base = "Covered Hopper"
+
+[STR_NAME_SUFFIX_CRYO_TANK_CAR]
+base = "Cryo Tank Car"
+
+[STR_NAME_SUFFIX_CURTAIN_SIDE_BOX_CAR]
+base = "Curtain Side Boxcar"
+
+[STR_NAME_SUFFIX_DOUBLE_DECK_AUTOMOBILE_CAR]
+base = "Autorack"
+
+[STR_NAME_SUFFIX_DRY_POWDER_HOPPER_CAR]
+base = "Covered Hopper"
+
+[STR_NAME_SUFFIX_DUMP_CAR]
+base = "Mineral Hopper"
+
+[STR_NAME_SUFFIX_DUMP_CAR_HIGH_SIDE]
+base = "High Side Mineral Hopper"
+
+[STR_NAME_SUFFIX_EDIBLES_TANK_CAR]
+base = "Edibles Tank Car"
+
+[STR_NAME_SUFFIX_ENCLOSED_AUTOMOBILE_CAR]
+base = "Enclosed Autorack"
+
+[STR_NAME_SUFFIX_EXPRESS_CAR]
+base = "Express Boxcar"
+
+[STR_NAME_SUFFIX_EXPRESS_INTERMODAL_CAR]
+base = "Express Container Car"
+
+[STR_NAME_SUFFIX_FARM_PRODUCTS_BOX_CAR]
+base = "Farm Products Boxcar"
+
+[STR_NAME_SUFFIX_FARM_PRODUCTS_HOPPER_CAR_TYPE_1]
+base = "Farm Products Hopper"
+
+[STR_NAME_SUFFIX_FARM_PRODUCTS_HOPPER_CAR_TYPE_2]
+base = "Farm Products Hopper"
+
+[STR_NAME_SUFFIX_FLAT_CAR]
+base = "Flatcar"
+
+[STR_NAME_SUFFIX_GOODS_BOX_CAR]
+base = "Goods Boxcar"
+
+[STR_NAME_SUFFIX_HEAVY_DUTY_DUMP_CAR]
+base= "Heavy Duty Bulk Car"
+
+[STR_NAME_SUFFIX_HEAVY_DUTY_FLAT_CAR]
+base= "Heavy Duty Flatcar"
+
+[STR_NAME_SUFFIX_HIGH_SPEED_MAIL_CAR]
+base= "High Speed Mail Car"
+
+[STR_NAME_SUFFIX_HIGH_SPEED_PASSENGER_CAR]
+base= "High Speed Passenger Car"
+
+[STR_NAME_SUFFIX_HOOD_OPEN_CAR]
+base = "Hood Open Car"
+
+[STR_NAME_SUFFIX_HOPPER_CAR]
+base = "Hopper"
+
+[STR_NAME_SUFFIX_HOPPER_CAR_HIGH_SIDE]
+base = "High Side Hopper"
+
+[STR_NAME_SUFFIX_HST_MAIL_CAR]
+base = "Mail Car"
+
+[STR_NAME_SUFFIX_HST_PASSENGER_CAR]
+base = "Passenger Car"
+
+[STR_NAME_SUFFIX_INGOT_CAR]
+base = "Ingot Car"
+
+[STR_NAME_SUFFIX_INTERMODAL_CAR]
+base = "Container Car"
+
+[STR_NAME_SUFFIX_KAOLIN_HOPPER_CAR]
+base = "China Clay Hopper"
+
+[STR_NAME_SUFFIX_LIVESTOCK_CAR]
+base = "Livestock Boxcar"
+
+[STR_NAME_SUFFIX_LOG_CAR]
+base = "Log Carrier"
+
+[STR_NAME_SUFFIX_LOW_FLOOR_AUTOMOBILE_CAR]
+base = "Low-floor Autorack"
+
+[STR_NAME_SUFFIX_LOW_FLOOR_INTERMODAL_CAR]
+base = "Low-floor Container Car"
+
+[STR_NAME_SUFFIX_MAIL_CAR]
+base = "Mail Car"
+
+[STR_NAME_SUFFIX_MERCHANDISE_BOX_CAR]
+base = "Merchandise Boxcar"
+
+[STR_NAME_SUFFIX_MERCHANDISE_OPEN_CAR]
+base = "Merchandise Open"
+
+[STR_NAME_SUFFIX_MINERAL_COVERED_HOPPER_CAR]
+base = "Mineral Covered Hopper"
+
+[STR_NAME_SUFFIX_MGR_HOPPER_CAR]
+base = "MGR Hopper"
+
+[STR_NAME_SUFFIX_MGR_TOP_HOOD_HOPPER_CAR]
+base = "MGR Hood Hopper"
+
+[STR_NAME_SUFFIX_OPEN_CAR]
+base = "Open Car"
+
+[STR_NAME_SUFFIX_ORE_DUMP_CAR]
+base = "Ore Dump Hopper"
+
+[STR_NAME_SUFFIX_PANORAMIC_CAR]
+base = "Panoramic Car"
+
+[STR_NAME_SUFFIX_PASSENGER_CAR]
+base = "Passenger Car"
+
+[STR_NAME_SUFFIX_PEAT_CAR]
+base = "Peat Cars"
+
+[STR_NAME_SUFFIX_PLATE_CAR]
+base = "Plate Car"
+
+[STR_NAME_SUFFIX_PRESSURE_TANK_CAR]
+base = "Pressure Tank Car"
+
+[STR_NAME_SUFFIX_PRODUCT_TANK_CAR]
+base = "Product Tank Car"
+
+[STR_NAME_SUFFIX_RAILBUS_PASSENGER_TRAILER_CAR]
+base = "Railbus Trailer"
+
+[STR_NAME_SUFFIX_RAILCAR_PASSENGER_TRAILER_CAR]
+base = "Railcar Trailer"
+
+[STR_NAME_SUFFIX_RANDOMISED_AGGREGATE_HOPPER_CAR]
+base = "Aggregate Hopper"
+
+[STR_NAME_SUFFIX_RANDOMISED_AGGREGATE_DUMP_CAR]
+base = "Aggregate Dump Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_BOX_CAR]
+base = "Boxcar"
+
+[STR_NAME_SUFFIX_RANDOMISED_BULK_CAR]
+base = "Bulk Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_CEMENT_SILO_CAR]
+base = "Cement Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_CHEMICALS_TANK_CAR]
+base = "Chemicals Tank Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_COVERED_HOPPER_CAR]
+base = "Covered Hopper"
+
+[STR_NAME_SUFFIX_RANDOMISED_DEDICATED_COIL_CAR]
+base = "Coil Carrier"
+
+[STR_NAME_SUFFIX_RANDOMISED_DUMP_CAR]
+base = "Mineral Hopper"
+
+[STR_NAME_SUFFIX_RANDOMISED_FARM_PRODUCTS_HOPPER_CAR]
+base = "Farm Products Hopper"
+
+[STR_NAME_SUFFIX_RANDOMISED_FLAT_CAR]
+base = "Cargo Flatcar"
+
+[STR_NAME_SUFFIX_RANDOMISED_GENERIC_COIL_CAR]
+base = "Coil Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_HOPPER_CAR]
+base = "Hopper"
+
+[STR_NAME_SUFFIX_RANDOMISED_OPEN_CAR]
+base = "Open Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_PIECE_GOODS_CAR]
+base = "Piece Goods Car"
+
+[STR_NAME_SUFFIX_RANDOMISED_SILO_CAR]
+base = "Silo Car"
+
+[STR_NAME_SUFFIX_REEFER_CAR_TYPE_1]
+base = "Refrigerated Boxcar"
+
+[STR_NAME_SUFFIX_REEFER_CAR_TYPE_2]
+base = "Refrigerated Boxcar"
+
+[STR_NAME_SUFFIX_RESTAURANT_CAR]
+base = "Restaurant Car"
+
+[STR_NAME_SUFFIX_ROCK_HOPPER_CAR]
+base = "Rock Hopper"
+
+[STR_NAME_SUFFIX_ROLLER_ROOF_HOPPER_CAR]
+base = "Roller Roof Hopper"
+
+[STR_NAME_SUFFIX_SILO_CAR]
+base = "Silo Car"
+
+[STR_NAME_SUFFIX_SILO_CAR_V_BARREL]
+base = "Silo Car"
+
+[STR_NAME_SUFFIX_SKIP_CAR]
+base = "Skips"
+
+[STR_NAME_SUFFIX_SLAG_LADLE_CAR]
+base = "Slag Ladle Car"
+
+[STR_NAME_SUFFIX_SLIDING_ROOF_CAR]
+base = "Sliding Roof Boxcar"
+
+[STR_NAME_SUFFIX_SLIDING_ROOF_HI_CUBE_CAR]
+base = "Cube Car"
+
+[STR_NAME_SUFFIX_SLIDING_WALL_CAR]
+base = "Sliding Wall Boxcar"
+
+[STR_NAME_SUFFIX_SCRAP_METAL_CAR]
+base = "Scrap Car"
+
+[STR_NAME_SUFFIX_SUBURBAN_PASSENGER_CAR]
+base = "Suburban Car"
+
+[STR_NAME_SUFFIX_SULPHUR_TANK_CAR]
+base = "Acid Tank Car"
+
+[STR_NAME_SUFFIX_SWING_ROOF_HOPPER_CAR]
+base = "Swing Roof Hopper"
+
+[STR_NAME_SUFFIX_TANK_CAR]
+base = "Tank Car"
+
+[STR_NAME_SUFFIX_TARPAULIN_CAR]
+base = "Tarpaulin Car"
+
+[STR_NAME_SUFFIX_TORPEDO_CAR]
+base = "Torpedo Car"
+
+[STR_NAME_SUFFIX_VEHICLE_PARTS_BOX_CAR]
+base = "Sliding Wall Boxcar"
+
+# cargo subtypes - only used for automobile cars (specifically vehicles cargo) as of May 2021
+[STR_CARGO_SUBTYPE_VEHI_0]
+base = "(Cars)"
+
+[STR_CARGO_SUBTYPE_VEHI_1]
+base = "(Trucks)"
+
+# role information for buy menu
+[STR_ROLE]
+base = "{BLACK}Role: {GOLD}{STRING}"
+
+[STR_ROLE_DRIVING_CAB]
+base = "Driving Cab"
+
+[STR_ROLE_EXPRESS]
+base = "Express"
+
+[STR_ROLE_FREIGHT]
+base = "Freight"
+
+[STR_ROLE_GENERAL_PURPOSE]
+base = "General Purpose"
+
+[STR_ROLE_GENERAL_PURPOSE_EXPRESS]
+base = "General Purpose / Express"
+
+[STR_ROLE_GENERAL_PURPOSE_FREIGHT]
+base = "General Purpose / Freight"
+
+[STR_ROLE_GRONK]
+base = "Gronk!"
+
+[STR_ROLE_INTERCITY_EXPRESS]
+base = "InterCity Express"
+
+[STR_ROLE_LOLZ]
+base = "Lolz"
+
+[STR_ROLE_METRO]
+base = "Very High Capacity Urban"
+
+[STR_ROLE_SUBURBAN]
+base = "General Purpose / High Capacity"
+
+[STR_ROLE_VERY_HIGH_SPEED]
+base = "Very High Speed"
+
+[STR_POWER_BY_POWER_SOURCE_TWO_SOURCES]
+base = "{BLACK}Power on {STRING}: {GOLD}{POWER} {}{BLACK}Power on {STRING}: {GOLD}{POWER}"
+
+[STR_POWER_BY_POWER_SOURCE_THREE_SOURCES]
+base = "{BLACK}Power on {STRING}: {GOLD}{POWER} {}{BLACK}Power on {STRING}: {GOLD}{POWER} {}{BLACK}Power on {STRING}: {GOLD}{POWER}"
+
+[STR_POWER_SOURCE_AC]
+base = "Electric (AC)"
+
+[STR_POWER_SOURCE_BATTERY_HYBRID]
+base = "Battery Hybrid"
+
+[STR_POWER_SOURCE_DC]
+base = "Electric (DC)"
+
+[STR_POWER_SOURCE_METRO]
+base = "Metro"
+
+[STR_POWER_SOURCE_DIESEL]
+base = "Diesel"
+
+[STR_POWER_SOURCE_STEAM]
+base = "Steam"
+
+# assumed to be handling case of lgv_capable (two speeds)
+[STR_SPEED_BY_RAILTYPE_LGV_CAPABLE]
+base = "{BLACK}Speed (Dedicated High Speed Rail): {GOLD}{VELOCITY} {}{BLACK}Speed (Normal Rail): {GOLD}{VELOCITY}"
+
+# distributed power (dedicated wagons add power)
+[STR_WAGONS_ADD_POWER_CAB]
+base = "{BLACK}Power (Distributed): {GOLD}{POWER} per {STRING} passenger or mail car attached"
+
+[STR_WAGONS_ADD_POWER_MIDDLE]
+base = "{BLACK}Power (Distributed): {GOLD}{POWER} when attached to {STRING} engine"
+
+# other buy menu hints
+[STR_BUY_MENU_ADDITIONAL_TEXT_HINT_DRIVING_CAB]
+base = "{BLACK}Attach to front or rear of train, with at least one other engine"
+
+[STR_BUY_MENU_ADDITIONAL_TEXT_HINT_LGV_CAPABLE]
+base = "{BLACK}Requires dedicated high speed rails to reach maximum speed"
+
+[STR_BUY_MENU_ADDITIONAL_TEXT_HINT_RESTAURANT_CAR]
+base = "{}{BLACK}Bonus: {GOLD}Eliminates running costs for all Passenger Cars in the train"
+
+[STR_BUY_MENU_ADDITIONAL_TEXT_HINT_RESTAURANT_CAR_EXTENDED]
+base = "{}{BLACK}Bonus: {GOLD}Eliminates running costs for all Passenger Cars or High Speed Cars in the train"
+
+[STR_BUY_MENU_ADDITIONAL_TEXT_HINT_LIVERY_VARIANTS]
+base = "{}{BLACK}Color mix: {GOLD}{STRING}"
+
+# project management
+[STR_SPRITES_COMPLETE]
+base = "{}Sprites Complete: {GOLD}Yup"
+
+[STR_SPRITES_INCOMPLETE]
+base = "{}Sprites Complete: {GOLD}Nope"
+
+## rail types
+# lgv track strings
+# this type isn't built, it's unelectrified and exists for compatibility reasons, see electrified lgv instead
+[STR_RAILTYPE_LGV_NAME]
+base = "Dedicated High Speed Railroad"
+
+[STR_RAILTYPE_LGV_TOOLBAR_CAPTION]
+base = "[unused]"
+
+[STR_RAILTYPE_LGV_MENU_TEXT]
+base = "[unused]"
+
+[STR_RAILTYPE_LGV_BUILD_WINDOW_CAPTION]
+base = "New Dedicated High Speed Vehicles"
+
+[STR_RAILTYPE_LGV_AUTOREPLACE_TEXT]
+base = "Dedicated High Speed Vehicles"
+
+[STR_RAILTYPE_LGV_NEW_ENGINE_TEXT]
+base = "high speed rail vehicle"
+
+# lgv electrified track strings
+[STR_RAILTYPE_LGV_ELECTRIFIED_NAME]
+base = "Dedicated High Speed Railroad"
+
+[STR_RAILTYPE_LGV_ELECTRIFIED_TOOLBAR_CAPTION]
+base = "Dedicated High Speed Railroad Construction"
+
+[STR_RAILTYPE_LGV_ELECTRIFIED_MENU_TEXT]
+base = "Dedicated high speed railroad construction"
+
+[STR_RAILTYPE_LGV_ELECTRIFIED_BUILD_WINDOW_CAPTION]
+base = "New Dedicated High Speed Vehicles"
+
+[STR_RAILTYPE_LGV_ELECTRIFIED_AUTOREPLACE_TEXT]
+base = "Dedicated High Speed Vehicles"
+
+[STR_RAILTYPE_LGV_ELECTRIFIED_NEW_ENGINE_TEXT]
+base = "high speed rail vehicle"
+
+
+# metro track strings
+[STR_RAILTYPE_METRO_NAME]
+base = "Metro Railroad"
+
+[STR_RAILTYPE_METRO_TOOLBAR_CAPTION]
+base = "Metro Railroad Construction"
+
+[STR_RAILTYPE_METRO_MENU_TEXT]
+base = "Metro railroad construction"
+
+[STR_RAILTYPE_METRO_BUILD_WINDOW_CAPTION]
+base = "New Metro Vehicles"
+
+[STR_RAILTYPE_METRO_AUTOREPLACE_TEXT]
+base = "Metro Rail Vehicles"
+
+[STR_RAILTYPE_METRO_NEW_ENGINE_TEXT]
+base = "metro rail vehicle"
+
+
+# narrow gauge track strings
+[STR_RAILTYPE_NARROW_GAUGE_NAME]
+base = "Narrow Gauge Railroad"
+
+[STR_RAILTYPE_NARROW_GAUGE_TOOLBAR_CAPTION]
+base = "Narrow Gauge Railroad Construction"
+
+[STR_RAILTYPE_NARROW_GAUGE_MENU_TEXT]
+base = "Narrow gauge railroad construction"
+
+[STR_RAILTYPE_NARROW_GAUGE_BUILD_WINDOW_CAPTION]
+base = "New Narrow Gauge Vehicles"
+
+[STR_RAILTYPE_NARROW_GAUGE_AUTOREPLACE_TEXT]
+base = "Narrow Gauge Rail Vehicles"
+
+[STR_RAILTYPE_NARROW_GAUGE_NEW_ENGINE_TEXT]
+base = "narrow gauge rail vehicle"
+
+
+# narrow gauge electrified track strings
+[STR_RAILTYPE_NARROW_GAUGE_ELECTRIFIED_NAME]
+base = "Electrified Narrow Gauge Railroad"
+
+[STR_RAILTYPE_NARROW_GAUGE_ELECTRIFIED_TOOLBAR_CAPTION]
+base = "Electrified Narrow Gauge Railroad Construction"
+
+[STR_RAILTYPE_NARROW_GAUGE_ELECTRIFIED_MENU_TEXT]
+base = "Electrified narrow gauge railroad construction"
+
+[STR_RAILTYPE_NARROW_GAUGE_ELECTRIFIED_BUILD_WINDOW_CAPTION]
+base = "New Electrified Narrow Gauge Vehicles"
+
+[STR_RAILTYPE_NARROW_GAUGE_ELECTRIFIED_AUTOREPLACE_TEXT]
+base = "Electrified Narrow Gauge Vehicles"
+
+[STR_RAILTYPE_NARROW_GAUGE_ELECTRIFIED_NEW_ENGINE_TEXT]
+base = "electrified narrow gauge rail vehicle"
+
+
+# high clearance track strings
+[STR_RAILTYPE_RAIL_HIGH_CLEARANCE_NAME]
+base = "High Clearance Railroad"
+
+[STR_RAILTYPE_RAIL_HIGH_CLEARANCE_TOOLBAR_CAPTION]
+base = "High Clearance Railroad Construction"
+
+[STR_RAILTYPE_RAIL_HIGH_CLEARANCE_MENU_TEXT]
+base = "high clearance railroad construction"
+
+[STR_RAILTYPE_RAIL_HIGH_CLEARANCE_BUILD_WINDOW_CAPTION]
+base = "New High Clearance Vehicles"
+
+[STR_RAILTYPE_RAIL_HIGH_CLEARANCE_AUTOREPLACE_TEXT]
+base = "High Clearance Vehicles"
+
+[STR_RAILTYPE_RAIL_HIGH_CLEARANCE_NEW_ENGINE_TEXT]
+base = "high clearance rail vehicle"
+
+
+# electrified AC track strings
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_NAME]
+base = "AC Electrified Railroad"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_TOOLBAR_CAPTION]
+base = "AC Electrified Railroad Construction"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_MENU_TEXT]
+base = "AC electrified railroad construction"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_BUILD_WINDOW_CAPTION]
+base = "New AC Electrified Vehicles"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_AUTOREPLACE_TEXT]
+base = "AC Electrified Vehicles"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_NEW_ENGINE_TEXT]
+base = "AC electric rail vehicle"
+
+# rail electrified ac dc
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_DC_NAME]
+base = "[unused]"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_DC_TOOLBAR_CAPTION]
+base = "[unused]"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_DC_MENU_TEXT]
+base = "[unused]"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_DC_BUILD_WINDOW_CAPTION]
+base = "New AC / DC Electrified Vehicles"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_DC_AUTOREPLACE_TEXT]
+base = "AC / DC Electrified Vehicles"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_AC_DC_NEW_ENGINE_TEXT]
+base = "AC / DC electric rail vehicle"
+
+# rail electrified dc
+[STR_RAILTYPE_RAIL_ELECTRIFIED_DC_NAME]
+base = "DC Electrified Railroad"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_DC_TOOLBAR_CAPTION]
+base = "DC Electrified Railroad Construction"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_DC_MENU_TEXT]
+base = "DC electrified railroad construction"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_DC_BUILD_WINDOW_CAPTION]
+base = "New DC Electrified Vehicles"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_DC_AUTOREPLACE_TEXT]
+base = "DC Electrified Vehicles"
+
+[STR_RAILTYPE_RAIL_ELECTRIFIED_DC_NEW_ENGINE_TEXT]
+base = "DC electric rail vehicle"
+


### PR DESCRIPTION
Adding lang file for *English (US)*. I copied `english.toml` and updated it. I'm not sure what the `grflangid` should be. Please advise.

For language, I referred [OpenTTD en_US lang file](https://translator.openttd.org/download/openttd-master/en_US).

Other reference:
- [Union Pacific 101 - What Are All of the Different Rail Car Types?](https://www.up.com/customers/track-record/tr181121_rail_car_types.htm)